### PR TITLE
Hackathon refits

### DIFF
--- a/ChimpDriver/chimpDriver/src/main/java/edu/colorado/plv/chimp/driver/ChimpDriver.java
+++ b/ChimpDriver/chimpDriver/src/main/java/edu/colorado/plv/chimp/driver/ChimpDriver.java
@@ -119,6 +119,8 @@ abstract public class ChimpDriver /* <A extends Activity> */ extends PropertyAct
                 outcome = Outcome.CRASHED;
                 // Catch and release, because we want the Test Driver to recognize the exception and react accordingly.
                 throw e;
+                // exceptMsg = e.toString();
+                // return;
             }
         }
 

--- a/ChimpDriver/chimpDriver/src/main/java/edu/colorado/plv/chimp/driver/EspressoChimpDriver.java
+++ b/ChimpDriver/chimpDriver/src/main/java/edu/colorado/plv/chimp/driver/EspressoChimpDriver.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
+import android.graphics.Rect;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.AmbiguousViewMatcherException;
 import android.support.test.espresso.Espresso;
@@ -56,6 +57,7 @@ import static edu.colorado.plv.chimp.components.ViewID.ViewIDType.RID;
 import static edu.colorado.plv.chimp.components.ViewID.validOptionsMenu;
 import static org.hamcrest.Matchers.allOf;
 
+import edu.colorado.plv.chimp.viewactions.ChimpActionFactory;
 import edu.colorado.plv.chimp.viewactions.ChimpStagingAction;
 import edu.colorado.plv.chimp.viewactions.OrientationChangeAction;
 
@@ -196,6 +198,7 @@ public class EspressoChimpDriver /* <A extends Activity> */ extends ChimpDriver 
                     pe.printStackTrace();
                 } */
 
+                Log.i(runner.chimpTag("launchClick-WildCard"), "Beginning retrieval...");
                 try {
                     ArrayList<UiObject> uiObjects = wildCardManager.retrieveUiObjects(new UiSelector().clickable(true), new UiSelector().enabled(true));
 
@@ -205,23 +208,30 @@ public class EspressoChimpDriver /* <A extends Activity> */ extends ChimpDriver 
                         String display = "";
                         try {
                             display = wildCardManager.getUiObjectDisplay(uiObject);
-                            uiObject.click();
+                            // uiObject.click();
+
+                            Rect rect = uiObject.getBounds();
+                            Espresso.onView(isRoot()).perform(ChimpActionFactory.clickXY(rect.centerX(),rect.centerY()));
+
                             succ = true;
                         } catch (UiObjectNotFoundException e) {
-                            Log.e(runner.chimpTag("EspressoChimpDriver@launchClickEvent"), "Failed clicking on UIObject: " + wildCardManager.uiObjectInfo(uiObject), e);
+                            Log.e(runner.chimpTag("launchClick-WildCard"), "Failed clicking on UIObject: " + wildCardManager.uiObjectInfo(uiObject), e);
                         }
                         if (succ) {
                             AppEventOuterClass.Click.Builder builder = AppEventOuterClass.Click.newBuilder();
                             builder.setUiid(AppEventOuterClass.UIID.newBuilder().setIdType(AppEventOuterClass.UIID.UIIDType.NAME_ID).setNameid(display));
+
+                            Log.i(runner.chimpTag("launchClick-WildCard"), "Completed retrieval and execute.");
                             return builder.build();
                         }
                     }
 
                 } catch (UiObjectNotFoundException e) {
-                    Log.e(runner.chimpTag("EspressoChimpDriver@launchClickEvent"), "Error occurred at wild card top-level", e);
+                    Log.e(runner.chimpTag("launchClick-WildCard"), "Error occurred at wild card top-level", e);
                 }
 
-                Log.e(runner.chimpTag("EspressoChimpDriver@launchClickEvent"), "Exhausted all wild card options. Throwing exception.");
+
+                Log.e(runner.chimpTag("launchClick-WildCard"), "Exhausted all wild card options. Throwing exception.");
                 throw new NoViewEnabledException("Exhausted all wild card options.");
 
 

--- a/ChimpDriver/chimpDriver/src/main/java/edu/colorado/plv/chimp/managers/WildCardManager.java
+++ b/ChimpDriver/chimpDriver/src/main/java/edu/colorado/plv/chimp/managers/WildCardManager.java
@@ -106,7 +106,7 @@ public class WildCardManager {
 
         String str = "/***** Inferred Actionable UI Objects *****/\n";
         for(UiObject candidate: new HashSet<UiObject>(baseUiObjects)) {
-            str += "Found candidate: " + candidate.getClassName() + " " + candidate.getText() + " " + candidate.getContentDescription() + "\n";
+            str += "Found candidate: " + candidate.getClassName() + " " + candidate.getText() + " " + candidate.getContentDescription() + " UI Selector: " + candidate.getSelector().toString() + "\n";
         }
         str += "/******************************************/";
         Log.i("Chimp-wildCardManager",str);

--- a/ChimpDriver/chimpDriver/src/main/java/edu/colorado/plv/chimp/viewactions/ChimpActionFactory.java
+++ b/ChimpDriver/chimpDriver/src/main/java/edu/colorado/plv/chimp/viewactions/ChimpActionFactory.java
@@ -1,0 +1,36 @@
+package edu.colorado.plv.chimp.viewactions;
+
+import android.support.test.espresso.ViewAction;
+import android.support.test.espresso.action.CoordinatesProvider;
+import android.support.test.espresso.action.GeneralClickAction;
+import android.support.test.espresso.action.Press;
+import android.support.test.espresso.action.Tap;
+import android.view.View;
+
+/**
+ * Created by edmundlam on 5/16/17.
+ */
+
+public class ChimpActionFactory {
+
+    public static ViewAction clickXY(final int x, final int y){
+        return new GeneralClickAction(
+                Tap.SINGLE,
+                new CoordinatesProvider() {
+                    @Override
+                    public float[] calculateCoordinates(View view) {
+
+                        final int[] screenPos = new int[2];
+                        view.getLocationOnScreen(screenPos);
+
+                        final float screenX = screenPos[0] + x;
+                        final float screenY = screenPos[1] + y;
+                        float[] coordinates = {screenX, screenY};
+
+                        return coordinates;
+                    }
+                },
+                Press.FINGER);
+    }
+
+}

--- a/examples/ChimpSample1/ChimpChecker/src/main/scala/edu/colorado/plv/chimp/example/TestApp.scala
+++ b/examples/ChimpSample1/ChimpChecker/src/main/scala/edu/colorado/plv/chimp/example/TestApp.scala
@@ -6,7 +6,7 @@ import edu.colorado.plv.chimp.combinator.{Assert, Rotate, _}
 import edu.colorado.plv.chimp.combinator.Implicits._
 import edu.colorado.plv.chimp.generator.Implicits._
 import edu.colorado.plv.chimp.coordinator.{ChimpConfig, ChimpContext, ChimpLoader}
-import edu.colorado.plv.chimp.generator.{Gorilla, SubservientGorilla}
+import edu.colorado.plv.chimp.generator.{Gorilla, Repeat, SubservientGorilla}
 import edu.colorado.plv.chimp.coordinator.MissionControl._
 import org.scalacheck.Prop._
 import org.scalacheck.Prop.forAll
@@ -47,6 +47,8 @@ object RunBasic {
       tr => tr chimpCheck { true }
     }.check(myParam)
 
+    system.terminate();
+
   }
 
 }
@@ -83,6 +85,47 @@ object RunCustom {
     forAll(custom.generator) {
       tr => tr chimpCheck { true }
     }.check(myParam)
+
+    system.terminate()
+
+  }
+
+}
+
+object RunTestit {
+
+  def main(args: Array[String]): Unit = {
+
+    implicit val system = ActorSystem("my-system")
+    implicit val executionContext = system.dispatcher
+
+    // IMPORTANT !! Reset this to your local path to the ChimpSample1 APKs.
+    val apkDir = "/data/chimp/ChimpSample1"
+    // IMPORTANT !! Reset this to your Android SDK path. You will also need to ensure that Aapt 24.0.3 is available.
+    val androidSDKHome = "/Users/edmundlam/Library/Android/sdk"
+
+    val config = ChimpConfig.defaultConfig().withStartEmulator(false).withTestRun(false).withTimeout(720 seconds)
+      // .addDeviceInfo(DeviceInfo("emulator-5556"))
+      // .addDeviceInfo(DeviceInfo("emulator-5558"))
+      // .addDeviceInfo(DeviceInfo("emulator-5560"))
+      .withAPKs(s"$apkDir/app-debug.apk", s"$apkDir/app-debug-androidTest.apk", "TestExpresso")
+      .withAaptHome(s"$androidSDKHome/build-tools/24.0.3")
+
+    implicit val chimpContext = ChimpContext.initDefaultChimpContext(config)
+
+    implicit val gorillaConfig = Gorilla.defaultGorillaConfig
+
+    val myParam = Parameters.default.withMinSuccessfulTests(1).withWorkers(1)
+
+    val loginSeq = Type(R.id.input_username,"testuser") :>> Type(R.id.input_password,"1234") :>> Click(R.id.btn_login)
+
+    val custom = Click(R.id.button_begin) :>> Click(R.id.btn_login) :>> Click(R.id.interm_btn_cdt) :>> Click(R.id.btn_count10) :>> Click(R.id.btn_back) :>> Repeat(30, Click(*) :>> Skip)
+
+    forAll(Gorilla.generator) {
+      tr => tr chimpCheck { true }
+    }.check(myParam)
+
+    system.terminate()
 
   }
 


### PR DESCRIPTION
UI automator actions (e.g., click) were not only slow, they were causing the test driver to quit prematurely after a crash: particularly, chimp check error reports were not printed before the test driver ended. Solution was to use UI automator only for finding XY coordinates of the clickable views, then have Espresso do to generic click on XY coordinates.