### PR TITLE
implemented ChimpCheck result recovery (via reflection hack) in event…

### DIFF
--- a/ChimpDriver/chimpDriver/src/main/java/edu/colorado/plv/chimp/driver/ChimpDriver.java
+++ b/ChimpDriver/chimpDriver/src/main/java/edu/colorado/plv/chimp/driver/ChimpDriver.java
@@ -129,9 +129,33 @@ abstract public class ChimpDriver /* <A extends Activity> */ extends PropertyAct
         outcome = Outcome.SUCCESS;
     }
 
+    public void preemptiveTraceReport() {
+        Log.i(runner.chimpTag("@preemptiveTraceReport"), "Begin loading preemptive trace report...");
+
+        // Flush out any previously formatted preemptive reports
+        runner.flushReports();
+
+        // Append Executed Trace Report
+        EventTraceOuterClass.EventTrace.Builder builder = EventTraceOuterClass.EventTrace.newBuilder();
+        for(EventTraceOuterClass.UIEvent event: completedEvents) {
+            builder.addEvents( event );
+        }
+
+        String base64Output = Base64.encodeToString(builder.build().toByteArray(), Base64.DEFAULT);
+        runner.addReport("ChimpDriver-ExecutedTrace", base64Output);
+
+        runner.addReport("ChimpDriver-Outcome", "Crashed");
+
+        Log.i(runner.chimpTag("@preemptiveTraceReport"), "Preemptive Trace report completed!");
+
+    }
+
     @After
     public void processTraceReport() {
         Log.i(runner.chimpTag("@processTraceReport"), "Processing trace report...");
+
+        // Flush out any previously formatted preemptive reports
+        runner.flushReports();
 
         // Append Executed Trace Report
         EventTraceOuterClass.EventTrace.Builder builder = EventTraceOuterClass.EventTrace.newBuilder();

--- a/ChimpDriver/chimpDriver/src/main/java/edu/colorado/plv/chimp/driver/ChimpJUnitRunner.java
+++ b/ChimpDriver/chimpDriver/src/main/java/edu/colorado/plv/chimp/driver/ChimpJUnitRunner.java
@@ -5,6 +5,7 @@ package edu.colorado.plv.chimp.driver;
  */
 
 import android.os.Bundle;
+import android.support.test.internal.runner.listener.InstrumentationResultPrinter;
 import android.support.test.runner.AndroidJUnitRunner;
 
 import android.util.Base64;
@@ -12,6 +13,8 @@ import android.util.Log;
 import chimp.protobuf.*;
 import com.google.protobuf.InvalidProtocolBufferException;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -55,6 +58,50 @@ public class ChimpJUnitRunner extends AndroidJUnitRunner {
         }
     }
 
+    // This override is necessary to solve the 'missing ChimpCheck result issue'
+    // Particularly, it is caused by UI Automator APIs: exception in the app is treated as exception in the tester.
+    // This override intercepts such untimely exceptions and injects the ChimpCheck results.
+    // Note: works in conjunction with 'preemptiveTraceReport' of ChimpDriver
+    @Override
+    public boolean onException(Object obj, Throwable e) {
+
+        Log.e("ChimpDriver",String.format("ChimpJUnitRunner onException was called: %s \n super class: %s", e.toString(), super.getClass()));
+
+        InstrumentationResultPrinter resultPrinter = null;
+        boolean succ = false;
+
+        // Use reflection to get the instrumentation result printer
+        try {
+            Method method = this.getClass().getSuperclass().getDeclaredMethod("getInstrumentationResultPrinter");
+            method.setAccessible(true);
+            resultPrinter = (InstrumentationResultPrinter) method.invoke(this);
+            succ = true;
+        } catch (Exception allEs) {
+            Log.e("ChimpDriver", "Error while reflecting on ChimpJUnitRunner: " + allEs.toString());
+        }
+
+        Log.e("ChimpDriver", "Extracted Results: " + succ + " " + (resultPrinter != null) );
+
+        // Use reflection to extract the result bundle from the instrumentation result printer,
+        // then inject ChimpCheck results into the result bundle
+        if (resultPrinter != null) {
+            try {
+                Field field = resultPrinter.getClass().getDeclaredField("mTestResult");
+                field.setAccessible(true);
+                Bundle bundle = (Bundle) field.get(resultPrinter);
+                bundle.putString("ChimpCheck-ReflectionHack","Enabled");
+                // Append ChimpCheck results into the result bundle
+                for(Map.Entry<String,String> entry : chimpReports.entrySet()) {
+                    bundle.putString(entry.getKey(), entry.getValue());
+                }
+            } catch (Exception allEs) {
+                Log.e("ChimpDriver", "Error while reflecting on Instrumentation Result Printer: " + allEs.toString());
+            }
+        }
+
+        return super.onException(obj,e);
+    }
+
     @Override
     public void finish(int code, Bundle bundle) {
         // bundle.putString("chimp-check", "Little monkeys.");
@@ -74,6 +121,10 @@ public class ChimpJUnitRunner extends AndroidJUnitRunner {
     public String getAppPackageName() { return appPackageName; }
 
     public void addReport(String key, String data) { chimpReports.put(key, data); }
+
+    public void removeReport(String key) { chimpReports.remove(key); }
+
+    public void flushReports() { chimpReports = new HashMap<String, String>(); }
 
     public String chimpTag(String tag) { return String.format("%s:%s",chimpName, tag); }
 

--- a/ChimpDriver/chimpDriver/src/main/java/edu/colorado/plv/chimp/driver/EspressoChimpDriver.java
+++ b/ChimpDriver/chimpDriver/src/main/java/edu/colorado/plv/chimp/driver/EspressoChimpDriver.java
@@ -199,6 +199,12 @@ public class EspressoChimpDriver /* <A extends Activity> */ extends ChimpDriver 
                 } */
 
                 Log.i(runner.chimpTag("launchClick-WildCard"), "Beginning retrieval...");
+
+                // Before handling over control to the UI automator, we format a preemptive report:
+                //  If crash in app happens during the critical section below, UI automator suppresses all exceptions and prevents all
+                //  @After routines from even running at all.
+                preemptiveTraceReport();
+
                 try {
                     ArrayList<UiObject> uiObjects = wildCardManager.retrieveUiObjects(new UiSelector().clickable(true), new UiSelector().enabled(true));
 
@@ -207,10 +213,12 @@ public class EspressoChimpDriver /* <A extends Activity> */ extends ChimpDriver 
                         boolean succ = false;
                         String display = "";
                         try {
+                            Log.i(runner.chimpTag("launchClick-WildCard"), "Retrieving display information from UIObject");
                             display = wildCardManager.getUiObjectDisplay(uiObject);
                             // uiObject.click();
-
+                            Log.i(runner.chimpTag("launchClick-WildCard"), "Retrieving display bounds from UIObject");
                             Rect rect = uiObject.getBounds();
+                            Log.i(runner.chimpTag("launchClick-WildCard"), "Executing espresso action");
                             Espresso.onView(isRoot()).perform(ChimpActionFactory.clickXY(rect.centerX(),rect.centerY()));
 
                             succ = true;

--- a/examples/ChimpSample1/ChimpChecker/src/main/scala/edu/colorado/plv/chimp/example/TestApp.scala
+++ b/examples/ChimpSample1/ChimpChecker/src/main/scala/edu/colorado/plv/chimp/example/TestApp.scala
@@ -121,7 +121,7 @@ object RunTestit {
 
     val custom = Click(R.id.button_begin) :>> Click(R.id.btn_login) :>> Click(R.id.interm_btn_cdt) :>> Click(R.id.btn_count10) :>> Click(R.id.btn_back) :>> Repeat(30, Click(*) :>> Skip)
 
-    forAll(Gorilla.generator) {
+    forAll(custom.generator) {
       tr => tr chimpCheck { true }
     }.check(myParam)
 


### PR DESCRIPTION
Unfortunately, the previous merge did not entirely solve the problem of missing ChimpCheck results.

This merge fully solves the issue, but unfortunately uses Java reflection hacks.

Problem: UI automator causes the test driver to throw exception, when the tested app throws an exception. This happens when the app exception is thrown at the same time a UI automator method is executing. Attempts to suppress this exception (try, catch, etc..) did not work.

Solution: override the onException method of the JUnitRunner, particularly, we want to inject the ChimpCheck results when the test driver throws uncaught an exception. However, there is no native access to the result bundle from onException, hence we need to use reflection to access a private method and private field to gain access to this bundle. It works, but the lord of good programming practice might not be happy.
